### PR TITLE
Add Qt module info to aqt cache

### DIFF
--- a/src/cache_aqt_list_output.py
+++ b/src/cache_aqt_list_output.py
@@ -1,10 +1,14 @@
 import logging
 import json
+import posixpath
+import re
 from collections.abc import Iterator
 from pathlib import Path
-from typing import Dict, List, Optional, TypedDict, TypeVar, Callable, Set
+from typing import Dict, Optional, TypedDict, TypeVar, Callable, Set
 
-from aqt.metadata import ArchiveId, MetadataFactory, Version
+from aqt.metadata import ArchiveId, MetadataFactory, Version, QtRepoProperty
+
+from html_util import iter_folders
 
 logger = logging.getLogger(__name__)
 PUBLIC_ROOT = Path(__file__).parent.parent / "public"
@@ -27,9 +31,12 @@ def log_and_reraise_exceptions(fn: Callable[[], T], msg: str, *args) -> T:
         raise
 
 class CachedMetadata:
+    # matches '5.9.4-0-201801211432qtbase-Windows-Windows_7-Mingw53-Android-Android_ANY-ARMv7.7z'
+    archive_name_pattern = re.compile(r"^\d+(?:\.\d+){2}-\d+-\d{12}(?P<archive>\w+)-")
+
     class CacheForArch(TypedDict):
         modules: Dict[str, Dict[str, str]]
-        archives: List[str]
+        archives: Dict[str, str]
 
     def __init__(self, archive_id: ArchiveId):
         self.meta = MetadataFactory(archive_id)
@@ -79,15 +86,40 @@ class CachedMetadata:
                     f"Failed fetching modules for %s version=%s arch=%s",
                     self.meta.archive_id, version, arch,
                 )
-                archives = log_and_reraise_exceptions(
+                archive_names = log_and_reraise_exceptions(
                     lambda: self.meta.fetch_archives(version, arch, []),
                     f"Failed fetching qt archives for %s version=%s arch=%s",
                     self.meta.archive_id, version, arch,
                 )
+                # version_date = modules.table_data[next(iter(modules.table_data))]['Version']
+                all_archives = self.fetch_archive_sizes(version, arch)
+                # archives = {archive: all_archives.get(archive, None) for archive in archive_names}
+                archives = {archive: all_archives[archive] for archive in archive_names}
                 cache[arch] = {'modules': modules.table_data, 'archives': archives}
             return cache
         except Exception:
             return None
+
+    def fetch_archive_sizes(self, version: Version, arch: str) -> Dict[str, str]:
+        def should_use_7z(filename: str) -> bool:
+            return filename.endswith(".7z") and not filename.endswith("meta.7z")
+
+        archive_sizes: Dict[str, str] = {}
+        qt_version_str = self.meta._get_qt_version_str(version)
+        module_name = f"qt.qt{version.major}.{qt_version_str}.{arch}" # Not true for all: should come from xml metadata
+        if version < Version("5.9.7"):
+            module_name = f"qt.{qt_version_str}.{arch}"
+
+        # Get the path to the updates.xml file
+        extension = QtRepoProperty.extension_for_arch(arch, version >= Version("6.0.0"))
+        folder = self.meta.archive_id.to_folder(version, qt_version_str, extension)
+        # updates_xml_rest_of_url = posixpath.join(self.meta.archive_id.to_url(), folder, "Updates.xml")
+        rest_of_url = posixpath.join(self.meta.archive_id.to_url(), folder, module_name) + '/'
+        html_doc = self.meta.fetch_http(rest_of_url, is_check_hash=False)
+        for filename_7z, _, archive_size in iter_folders(html_doc, should_use_7z):
+            if match := CachedMetadata.archive_name_pattern.match(filename_7z):
+                archive_sizes[match.group("archive")] = archive_size
+        return archive_sizes
 
     def has_cache_entry_for(self, version: Version) -> bool:
         return self.path(version).exists()

--- a/src/cache_aqt_list_output.py
+++ b/src/cache_aqt_list_output.py
@@ -28,7 +28,7 @@ def log_and_reraise_exceptions(fn: Callable[[], T], msg: str, *args) -> T:
 
 class CachedMetadata:
     class CacheForArch(TypedDict):
-        modules: List[str]
+        modules: Dict[str, Dict[str, str]]
         archives: List[str]
 
     def __init__(self, archive_id: ArchiveId):
@@ -75,7 +75,7 @@ class CachedMetadata:
             cache: Dict[str, CachedMetadata.CacheForArch] = {}
             for arch in arches:
                 modules = log_and_reraise_exceptions(
-                    lambda: self.meta.fetch_modules(version, arch),
+                    lambda: self.meta.fetch_long_modules(version, arch),
                     f"Failed fetching modules for %s version=%s arch=%s",
                     self.meta.archive_id, version, arch,
                 )
@@ -84,7 +84,7 @@ class CachedMetadata:
                     f"Failed fetching qt archives for %s version=%s arch=%s",
                     self.meta.archive_id, version, arch,
                 )
-                cache[arch] = {'modules': modules, 'archives': archives}
+                cache[arch] = {'modules': modules.table_data, 'archives': archives}
             return cache
         except Exception:
             return None

--- a/src/cache_aqt_list_output.py
+++ b/src/cache_aqt_list_output.py
@@ -112,24 +112,24 @@ class CachedMetadata:
 
         tmp_path.replace(path)
 
-    def refresh_all_cache(self):
+    def refresh_all_cache(self, is_force_refresh: bool) -> None:
         cached_versions: Set[Version] = set()
         versions = self.meta.fetch_versions()
         last_version = versions.latest()
         for version in versions.flattened():
             if self.has_cache_entry_for(version):
                 cached_versions.add(version)
-            if self.should_update_cache(version, last_version):
+            if is_force_refresh or self.should_update_cache(version, last_version):
                 made_update = self.update_cache_for(version)
                 if made_update:
                     cached_versions.add(version)
         self.write_cache_directory(cached_versions)
 
 
-def cache_aqt_list_qt() -> None:
+def cache_aqt_list_qt(is_force_refresh: bool = False) -> None:
     for archive_id in iter_archive_ids():
         cached_data = CachedMetadata(archive_id)
-        cached_data.refresh_all_cache()
+        cached_data.refresh_all_cache(is_force_refresh)
 
 
 

--- a/src/cache_updates.py
+++ b/src/cache_updates.py
@@ -15,20 +15,18 @@ from aqt.metadata import ArchiveId, MetadataFactory, get_semantic_version
 
 from cached_directory import CachedDirectory
 from cache_aqt_list_output import cache_aqt_list_qt
+from html_util import iter_html_content, iter_folders
 
 requests_cache.install_cache("aqt_list_http_cache")
 fetch_http = aqt.metadata.MetadataFactory.fetch_http
 logging.basicConfig()
 LOGGER = logging.getLogger()
 LOGGER.setLevel(logging.INFO)
-DEV_REGEX = re.compile(r"^qt\d_dev")
 PUBLIC_ROOT = Path(__file__).parent.parent / "public"
 LAST_UPDATED_JSON_FILE = PUBLIC_ROOT / "last_updated.json"
 INDENT_SIZE = 1
 REQUIRED_FETCH_DEPTH = 1
 
-# Allowed tools that don't start with 'tools_' (see aqtinstall#677)
-HARDCODED_ALLOWED_TOOLS = ('sdktool',)
 
 
 def banner_message(msg: str):
@@ -41,45 +39,6 @@ def iterate_hosts_targets() -> Generator[Tuple[str, str], None, None]:
     for host in ArchiveId.HOSTS:
         for target in ArchiveId.TARGETS_FOR_HOST[host]:
             yield host, target
-
-
-UNSUPPORTED_FOLDER_REGEX = re.compile(r"^qt6_(\d{1,2})_(\d{1,2})")
-def is_qt_or_tools(folder: str) -> bool:
-    if DEV_REGEX.match(folder) is not None:
-        return False
-    if "backup" in folder or "preview" in folder:
-        return False
-    # TODO: when aqtinstall works with folders that look like `qt6_7_3`, remove this!
-    # Depends on aqtinstall/issues/817
-    if UNSUPPORTED_FOLDER_REGEX.match(folder) is not None:
-        return False
-    return folder.startswith("tools_") or folder.startswith("qt") or folder in HARDCODED_ALLOWED_TOOLS
-
-
-def iter_folders(
-    html_doc: str, folder_predicate: Callable[[str], bool] = is_qt_or_tools
-):
-    yield from iter_html_content(html_doc, folder_predicate, lambda s: s.rstrip("/"))
-
-
-def iter_html_content(
-    html_doc: str, item_predicate: Callable[[str], bool], transform_item: Callable[[str], str] = lambda s: s
-) -> Generator[Tuple[str, datetime, str], None, None]:
-    def table_row_to_folder(tr: bs4.element.Tag) -> Tuple[str, datetime, str]:
-        _folder: str = transform_item(tr.find_all("td")[1].a.contents[0].strip())
-        date_str = tr.find_all("td")[2].contents[0].strip()
-        _dt = datetime.strptime(date_str, "%d-%b-%Y %H:%M")
-        _size_str = tr.find_all("td")[3].contents[0].strip()
-        return _folder, _dt, _size_str
-
-    soup: bs4.BeautifulSoup = bs4.BeautifulSoup(html_doc, "html.parser")
-    for row in soup.body.table.find_all("tr"):
-        try:
-            folder, dt, size_str = table_row_to_folder(row)
-            if item_predicate(folder):
-                yield folder, dt, size_str
-        except (AttributeError, IndexError, ValueError):
-            continue
 
 
 """

--- a/src/html_util.py
+++ b/src/html_util.py
@@ -1,0 +1,49 @@
+import re
+from datetime import datetime
+from typing import Callable, Generator, Tuple
+
+import bs4
+
+DEV_REGEX = re.compile(r"^qt\d_dev")
+UNSUPPORTED_FOLDER_REGEX = re.compile(r"^qt6_(\d{1,2})_(\d{1,2})")
+# Allowed tools that don't start with 'tools_' (see aqtinstall#677)
+HARDCODED_ALLOWED_TOOLS = ('sdktool',)
+
+def is_qt_or_tools(folder: str) -> bool:
+    if DEV_REGEX.match(folder) is not None:
+        return False
+    if "backup" in folder or "preview" in folder:
+        return False
+    # TODO: when aqtinstall works with folders that look like `qt6_7_3`, remove this!
+    # Depends on aqtinstall/issues/817
+    if UNSUPPORTED_FOLDER_REGEX.match(folder) is not None:
+        return False
+    return folder.startswith("tools_") or folder.startswith("qt") or folder in HARDCODED_ALLOWED_TOOLS
+
+
+def iter_folders(
+    html_doc: str, folder_predicate: Callable[[str], bool] = is_qt_or_tools
+):
+    yield from iter_html_content(html_doc, folder_predicate, lambda s: s.rstrip("/"))
+
+
+def iter_html_content(
+    html_doc: str, item_predicate: Callable[[str], bool], transform_item: Callable[[str], str] = lambda s: s
+) -> Generator[Tuple[str, datetime, str], None, None]:
+    def table_row_to_folder(tr: bs4.element.Tag) -> Tuple[str, datetime, str]:
+        _folder: str = transform_item(tr.find_all("td")[1].a.contents[0].strip())
+        date_str = tr.find_all("td")[2].contents[0].strip()
+        _dt = datetime.strptime(date_str, "%d-%b-%Y %H:%M")
+        _size_str = tr.find_all("td")[3].contents[0].strip()
+        return _folder, _dt, _size_str
+
+    soup: bs4.BeautifulSoup = bs4.BeautifulSoup(html_doc, "html.parser")
+    for row in soup.body.table.find_all("tr"):
+        try:
+            folder, dt, size_str = table_row_to_folder(row)
+            if item_predicate(folder):
+                yield folder, dt, size_str
+        except (AttributeError, IndexError, ValueError):
+            continue
+
+


### PR DESCRIPTION
#3 added an additional cache that mimics the output of `aqt list-qt`, rather than simply caching the contents of all the updates.xml files in the repo. This cache was insufficient for storing all the data aqt-list-server needs to display.

This change adds all the module info to the cache: descriptions, names, sizes, etc. It also caches the sizes of individual archives. Additionally, it adds a flag that forces CI to regenerate the entire cache: This will be necessary to add all this data to existing cache entries.